### PR TITLE
scrapy-splash compatible proxy setting

### DIFF
--- a/scrapyx_luminati/luminati.py
+++ b/scrapyx_luminati/luminati.py
@@ -19,4 +19,7 @@ class LumninatiProxyMiddleware(object):
         return o
 
     def process_request(self, request, spider):
-        request.meta['proxy'] = self.proxy
+        if 'splash' in request.meta:
+            request.meta['splash']['args']['proxy'] = self.proxy
+        else:
+            request.meta['proxy'] = self.proxy


### PR DESCRIPTION
I've added the `if` statement to set proxy request.META HTTP header differently, in case of 'splash' is among the headers, as this makes it work with `scrapy-splash` package, run within docker as `docker run -p 8050:8050 scrapinghub/splash`.

This fixes #2 